### PR TITLE
feat: add API endpoint for raw markdown access

### DIFF
--- a/src/pages/posts/[slug]/index.md.ts
+++ b/src/pages/posts/[slug]/index.md.ts
@@ -1,0 +1,39 @@
+import { type CollectionEntry, getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+import fs from "node:fs";
+import path from "node:path";
+
+export async function getStaticPaths() {
+	const posts = await getCollection("blog", ({ data }) => !data.draft);
+
+	return posts.map((post) => ({
+		params: { slug: post.slug },
+		props: { post },
+	}));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+	const post = props.post as CollectionEntry<"blog">;
+
+	const filePath = path.join(process.cwd(), "src/content/blog", post.id);
+
+	try {
+		const markdown = fs.readFileSync(filePath, "utf-8");
+
+		return new Response(markdown, {
+			headers: {
+				"Content-Type": "text/markdown; charset=utf-8",
+			},
+		});
+	} catch (error) {
+		return new Response(
+			`Markdown file not found\npost.id: ${post.id}\npost.slug: ${post.slug}\nAttempted path: ${filePath}`,
+			{
+				status: 404,
+				headers: {
+					"Content-Type": "text/plain; charset=utf-8",
+				},
+			},
+		);
+	}
+};


### PR DESCRIPTION
Enable direct access to blog post markdown content via API route to support features requiring source markdown (e.g., external editors, markdown previews, or content management tools)