### PR TITLE
feat: adopt IBM Plex Sans JP for improved Japanese typography

### DIFF
--- a/apps/blog/src/components/Tag.astro
+++ b/apps/blog/src/components/Tag.astro
@@ -33,6 +33,6 @@ const { tag, size = "sm" } = Astro.props;
     @apply relative underline decoration-dashed hover:-top-0.5 hover:text-skin-accent focus-visible:p-1;
   }
   a svg {
-    @apply -mr-5 h-6 w-6 scale-95 text-skin-base opacity-80 group-hover:fill-skin-accent;
+    @apply -mr-2 h-6 w-6 scale-95 text-skin-base opacity-80 group-hover:fill-skin-accent;
   }
 </style>

--- a/apps/blog/src/layouts/Layout.astro
+++ b/apps/blog/src/layouts/Layout.astro
@@ -111,7 +111,7 @@ const structuredData = {
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=IBM+Plex+Sans+JP:wght@400;500;600;700&display=swap"
       rel="preload"
       as="style"
       onload="this.onload=null; this.rel='stylesheet';"

--- a/apps/blog/src/styles/base.css
+++ b/apps/blog/src/styles/base.css
@@ -29,7 +29,7 @@
 		display: block;
 	}
 	body {
-		@apply flex min-h-[100svh] flex-col bg-skin-fill font-mono text-skin-base selection:bg-skin-accent/70 selection:text-skin-inverted;
+		@apply flex min-h-[100svh] flex-col bg-skin-fill font-sans text-skin-base selection:bg-skin-accent/70 selection:text-skin-inverted;
 	}
 	section,
 	footer {
@@ -96,6 +96,10 @@
 	/* ===== Code Blocks & Syntax Highlighting ===== */
 	pre:has(code) {
 		@apply border border-skin-line;
+	}
+	pre,
+	code {
+		@apply font-mono;
 	}
 	code,
 	blockquote {

--- a/apps/blog/tailwind.config.cjs
+++ b/apps/blog/tailwind.config.cjs
@@ -60,6 +60,7 @@ module.exports = {
 				},
 			},
 			fontFamily: {
+				sans: ["IBM Plex Sans JP", "sans-serif"],
 				mono: ["IBM Plex Mono", "monospace"],
 			},
 


### PR DESCRIPTION
Switch body font from monospace to sans-serif (IBM Plex Sans JP) to improve readability and visual hierarchy, particularly for Japanese text. Ensure code blocks explicitly use monospace font to maintain code legibility. Adjust tag icon spacing to account for the new font metrics.