### PR TITLE
blog: assign tags to articles and lock the tag list to an enum

### DIFF
--- a/apps/blog/src/components/Tag.astro
+++ b/apps/blog/src/components/Tag.astro
@@ -2,9 +2,10 @@
 export interface Props {
 	tag: string;
 	size?: "sm" | "lg";
+	count?: number;
 }
 
-const { tag, size = "sm" } = Astro.props;
+const { tag, size = "sm", count } = Astro.props;
 ---
 
 <li
@@ -24,7 +25,11 @@ const { tag, size = "sm" } = Astro.props;
         d="M16.018 3.815 15.232 8h-4.966l.716-3.815-1.964-.37L8.232 8H4v2h3.857l-.751 4H3v2h3.731l-.714 3.805 1.965.369L8.766 16h4.966l-.714 3.805 1.965.369.783-4.174H20v-2h-3.859l.751-4H21V8h-3.733l.716-3.815-1.965-.37zM14.106 14H9.141l.751-4h4.966l-.752 4z"
       ></path>
     </svg>
-    &nbsp;<span>{tag}</span>
+    &nbsp;<span>{tag}</span>{
+      count !== undefined && (
+        <span class="ml-1 opacity-70">({count})</span>
+      )
+    }
   </a>
 </li>
 

--- a/apps/blog/src/content/blog/2024-12-01-nix-advent-calendar.md
+++ b/apps/blog/src/content/blog/2024-12-01-nix-advent-calendar.md
@@ -2,6 +2,7 @@
 title: 2024年を振り返る
 pubDatetime: 2024-12-01
 description: "Nix アドベントカレンダーの一環として 2024 年の Nix 関連の活動を振り返る"
+tags: ["nix", "nixpkgs", "advent-calendar"]
 ---
 
 この記事は Nix アドベントカレンダー 2024 の1日の記事である。

--- a/apps/blog/src/content/blog/2025-05-07-snix-eval.md
+++ b/apps/blog/src/content/blog/2025-05-07-snix-eval.md
@@ -2,6 +2,7 @@
 title: snix-evalを使ってRustで式を評価する
 pubDatetime: 2025-05-07
 description: 外部コマンド (nix) に依存せずにアプリケーション単体でNixのコードを評価する方法と現状の制約
+tags: ["nix", "rust", "snix"]
 ---
 
 ## はじめに

--- a/apps/blog/src/content/blog/2025-07-09-macos-snapshot.md
+++ b/apps/blog/src/content/blog/2025-07-09-macos-snapshot.md
@@ -2,6 +2,7 @@
 title: macOSでTime Machineを有効化せずスナップショットをとる
 pubDatetime: 2025-07-09
 description: Time Machineをセットアップせずに、コマンドラインからAPFSスナップショットを作成し、AIコーディングツールなどによる不慮のファイル変更からシステムを保護しよう
+tags: ["macos", "backup"]
 ---
 
 ## はじめに

--- a/apps/blog/src/content/blog/2025-12-01-nix-advent-calendar.md
+++ b/apps/blog/src/content/blog/2025-12-01-nix-advent-calendar.md
@@ -2,6 +2,7 @@
 title: Nixと文芸的プログラミング
 pubDatetime: 2025-12-01
 description: "Nixによる宣言的な設定の意図を文芸的プログラミングを用いて記録する"
+tags: ["nix", "advent-calendar", "literate-programming", "emacs"]
 ---
 
 この記事は [Nix アドベントカレンダー 2025](https://adventar.org/calendars/11657) の1日目の記事である。

--- a/apps/blog/src/content/blog/2026-01-11-license.md
+++ b/apps/blog/src/content/blog/2026-01-11-license.md
@@ -2,6 +2,7 @@
 title: OSSとライセンス
 pubDatetime: 2026-01-11
 description: "このブログに対するライセンスの変更とその背景について"
+tags: ["oss", "license"]
 ---
 
 今回、本ブログにおけるコンテンツのライセンス規定を見直し、

--- a/apps/blog/src/content/config.ts
+++ b/apps/blog/src/content/config.ts
@@ -2,6 +2,24 @@ import { defineCollection, z } from "astro:content";
 import { SITE } from "@config";
 import { glob } from "astro/loaders";
 
+const TAGS = [
+	"advent-calendar",
+	"backup",
+	"beancount",
+	"dynamic-derivations",
+	"emacs",
+	"license",
+	"literate-programming",
+	"macos",
+	"nix",
+	"nixpkgs",
+	"oss",
+	"others",
+	"plain-text-accounting",
+	"rust",
+	"snix",
+] as const;
+
 const blog = defineCollection({
 	type: "content_layer",
 	loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
@@ -13,7 +31,7 @@ const blog = defineCollection({
 			title: z.string(),
 			featured: z.boolean().optional(),
 			draft: z.boolean().optional(),
-			tags: z.array(z.string()).default(["others"]),
+			tags: z.array(z.enum(TAGS)).default(["others"]),
 			ogImage: image()
 				.refine((img) => img.width >= 1200 && img.height >= 630, {
 					message: "OpenGraph image must be at least 1200 X 630 pixels!",

--- a/apps/blog/src/pages/tags/index.astro
+++ b/apps/blog/src/pages/tags/index.astro
@@ -17,7 +17,7 @@ const tags = getUniqueTags(posts);
   <Header activeNav="tags" />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
-      {tags.map(({ tag }) => <Tag {tag} size="lg" />)}
+      {tags.map(({ tag, count }) => <Tag {tag} {count} size="lg" />)}
     </ul>
   </Main>
   <Footer />

--- a/apps/blog/src/utils/getUniqueTags.ts
+++ b/apps/blog/src/utils/getUniqueTags.ts
@@ -5,19 +5,28 @@ import { slugifyStr } from "./slugify";
 interface Tag {
 	tag: string;
 	tagName: string;
+	count: number;
 }
 
 const getUniqueTags = (posts: CollectionEntry<"blog">[]) => {
-	const tags: Tag[] = posts
+	const counts = posts
 		.filter(postFilter)
 		.flatMap((post) => post.data.tags)
-		.map((tag) => ({ tag: slugifyStr(tag), tagName: tag }))
-		.filter(
-			(value, index, self) =>
-				self.findIndex((tag) => tag.tag === value.tag) === index,
-		)
-		.sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
-	return tags;
+		.reduce((acc, tagName) => {
+			const tag = slugifyStr(tagName);
+			return acc.set(tag, {
+				tag,
+				tagName,
+				count: (acc.get(tag)?.count ?? 0) + 1,
+			});
+		}, new Map<string, Tag>());
+
+	return [...counts.values()].sort((a, b) => {
+		if (a.tag === "others") return 1;
+		if (b.tag === "others") return -1;
+		if (a.count !== b.count) return b.count - a.count;
+		return a.tag.localeCompare(b.tag);
+	});
 };
 
 export default getUniqueTags;


### PR DESCRIPTION
## Summary
- Every article was relying on the schema default of `["others"]`, which made tag-based navigation effectively useless. Assign content-specific tags to each post.
- Tighten the schema from `z.array(z.string())` to `z.array(z.enum(TAGS))` so that any unknown or inconsistently spelled tag (case differences, hyphen vs underscore, near-duplicates) fails at content sync time. The canonical tag list now lives in `apps/blog/src/content/config.ts`, and adding a new tag becomes an explicit, reviewable change.

## Test plan
- [x] `pnpm --filter blog astro check` reports 0 errors
- [ ] Preview the deployed site and confirm each `/tags/<tag>` page renders the expected posts