### PR TITLE
fix: remove duplicate @shikijs/engine-javascript entry in pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3984,12 +3984,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-javascript@4.0.2':
-    dependencies:
-      '@shikijs/types': 4.0.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.4
-
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0


### PR DESCRIPTION
## Summary
- The shiki v4 update (#101) merged a corrupt `pnpm-lock.yaml` containing a duplicated `@shikijs/engine-javascript@4.0.2` snapshot key that referenced a non-existent `oniguruma-to-es: 4.3.4`.
- `pnpm install` on CI fails with `ERR_PNPM_BROKEN_LOCKFILE  ... duplicated mapping key (3987:3)`, breaking the `CI` and `Deploy` workflows on `main` ([failing run](https://github.com/natsukium/natsukium.com/actions/runs/25426593029)).
- This drops the stale duplicate so the lockfile parses again. Minimal diff (6 lines deleted) — no version churn.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] `pnpm test` (25 tests) passes
- [x] `pnpm build` succeeds
- [ ] Verify CI workflows pass on this PR