### PR TITLE
feat(blog): add atproto standard.site publishing and Bluesky comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Install dependencies
         run: nix profile add .#ci && pnpm install --frozen-lockfile
 
+      - name: Publish standard.site records
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.ATP_APP_PASSWORD != ''
+        run: pnpm -C apps/blog sync:standard-site
+        env:
+          ATP_IDENTIFIER: ${{ vars.ATP_IDENTIFIER }}
+          ATP_APP_PASSWORD: ${{ secrets.ATP_APP_PASSWORD }}
+
       - name: Build the project
         run: pnpm run build
         env:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -70,6 +70,14 @@
         "unicorn/consistent-function-scoping": "off",
         "vitest/no-conditional-in-test": "off"
       }
+    },
+    {
+      "files": ["**/scripts/**"],
+      "rules": {
+        "no-console": "off",
+        "eslint/no-await-in-loop": "off",
+        "eslint/max-lines": "off"
+      }
     }
   ],
   "settings": {

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -14,6 +14,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "lint:check": "oxlint --deny-warnings",
+    "sync:standard-site": "node scripts/sync-standard-site.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/blog/scripts/sync-standard-site.ts
+++ b/apps/blog/scripts/sync-standard-site.ts
@@ -1,0 +1,398 @@
+import { join, relative, sep } from "node:path";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { SITE } from "../src/config.ts";
+import { parse as parseYaml } from "yaml";
+
+// Publishes standard.site records to the author's PDS from the blog content.
+//
+// Both site.standard.publication and site.standard.document declare `key: "tid"`,
+// so record keys are server-assigned TIDs, not slugs, and must be recovered
+// rather than derived. Each run rebuilds the slug -> rkey map from the PDS itself
+// (listRecords, keyed by each document's `path`), which keeps the sync idempotent
+// even when run from CI where the committed src/data/standard-site.json cache is
+// empty or stale: relying on that cache alone, a lost rkey would createRecord a
+// duplicate. The committed json is only a build-time cache for environments that
+// render the verification tags without running this sync (local dev, previews).
+
+const appRoot = join(import.meta.dirname, "..");
+const mappingPath = join(appRoot, "src/data/standard-site.json");
+const blogDir = join(appRoot, "src/content/blog");
+
+// Resolved from the account's DID document at startup so a PDS migration is
+// followed automatically (records and AT-URIs are DID-based, so only the host
+// serving them moves). PDS_URL overrides this for local testing against a
+// specific host. Assigned before the first authenticated call.
+let pds = "";
+// The AppView is queried unauthenticated to turn a Bluesky post reference into a
+// strong ref (uri + cid) and to resolve a handle to a DID; it never touches the
+// author's PDS credentials.
+const PUBLIC_API = "https://public.api.bsky.app";
+const PLC_DIRECTORY = "https://plc.directory";
+const identifier = process.env.ATP_IDENTIFIER ?? process.env.ATP_HANDLE;
+const password = process.env.ATP_APP_PASSWORD ?? process.env.ATP_PASSWORD;
+
+if (!identifier || !password) {
+  console.error("Set ATP_IDENTIFIER (handle or DID) and ATP_APP_PASSWORD (app password).");
+  process.exit(1);
+}
+
+type Mapping = {
+  did: string;
+  publicationRkey: string | null;
+  documents: Record<string, string>;
+};
+
+type StrongRef = { uri: string; cid: string };
+
+type Frontmatter = {
+  title: string;
+  description?: string;
+  pubDatetime: string | Date;
+  modDatetime?: string | Date | null;
+  tags?: string[];
+  draft?: boolean;
+  bskyPostUri?: string;
+};
+
+async function xrpc(
+  nsid: string,
+  body: Record<string, unknown>,
+  jwt?: string,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${pds}/xrpc/${nsid}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`${nsid} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+// Returns the stored record's value, or null when it does not exist yet, so the
+// caller can decide between putRecord (unchanged records are skipped) and create.
+async function getRecord(
+  did: string,
+  collection: string,
+  rkey: string,
+): Promise<Record<string, unknown> | null> {
+  const params = new URLSearchParams({ repo: did, collection, rkey });
+  const res = await fetch(`${pds}/xrpc/com.atproto.repo.getRecord?${params.toString()}`);
+  if (res.status === 400) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error(`getRecord failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()).value as Record<string, unknown>;
+}
+
+type ListedRecord = { uri: string; value: Record<string, unknown> };
+
+// Lists every record in a collection, following the cursor so repos with more
+// than one page are fully covered. Read-only and unauthenticated: the records
+// are public, and this only reconstructs rkeys, never mutates.
+async function listAllRecords(did: string, collection: string): Promise<ListedRecord[]> {
+  const out: ListedRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const params = new URLSearchParams({ repo: did, collection, limit: "100" });
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+    const res = await fetch(`${pds}/xrpc/com.atproto.repo.listRecords?${params.toString()}`);
+    if (!res.ok) {
+      throw new Error(`listRecords failed: ${res.status} ${await res.text()}`);
+    }
+    const data = await res.json();
+    out.push(...(data.records as ListedRecord[]));
+    cursor = data.cursor as string | undefined;
+  } while (cursor);
+  return out;
+}
+
+// Resolve the login identifier to a DID: passed through if already a DID,
+// otherwise resolved from the handle via the AppView.
+async function resolveDid(id: string): Promise<string> {
+  if (id.startsWith("did:")) {
+    return id;
+  }
+  const res = await fetch(`${PUBLIC_API}/xrpc/com.atproto.identity.resolveHandle?handle=${id}`);
+  if (!res.ok) {
+    throw new Error(`Failed to resolve handle ${id}: ${res.status}`);
+  }
+  return (await res.json()).did as string;
+}
+
+// Read the account's DID document (did:plc via the directory, did:web via its
+// well-known) so the current PDS can be discovered rather than hard-coded.
+async function resolveDidDocument(did: string): Promise<Record<string, unknown>> {
+  let url: string;
+  if (did.startsWith("did:plc:")) {
+    url = `${PLC_DIRECTORY}/${did}`;
+  } else if (did.startsWith("did:web:")) {
+    url = `https://${did.slice("did:web:".length).replaceAll(":", "/")}/.well-known/did.json`;
+  } else {
+    throw new Error(`Unsupported DID method: ${did}`);
+  }
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`DID document lookup failed for ${did}: ${res.status}`);
+  }
+  return res.json();
+}
+
+type DidService = { id: string; serviceEndpoint: string };
+
+// The #atproto_pds service endpoint is the repo's current home; a migration just
+// rewrites it, so resolving it each run makes the sync follow the account.
+async function resolvePds(did: string): Promise<string> {
+  const doc = await resolveDidDocument(did);
+  const service = (doc.service as DidService[] | undefined)?.find((s) =>
+    s.id.endsWith("#atproto_pds"),
+  );
+  if (!service?.serviceEndpoint) {
+    throw new Error(`No #atproto_pds service in DID document for ${did}`);
+  }
+  return service.serviceEndpoint.replace(/\/+$/u, "");
+}
+
+function rkeyOf(uri: string): string {
+  return uri.split("/").pop() as string;
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+// Stable serialization (keys sorted at every depth) so records are compared by
+// value; this keeps unchanged posts from emitting spurious putRecord updates
+// that would otherwise stream to the firehose on every run.
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonical).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .toSorted()
+      .map((k) => `${JSON.stringify(k)}:${canonical((value as Record<string, unknown>)[k])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function parseFrontmatter(raw: string): Frontmatter {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/u);
+  if (!match) {
+    throw new Error("missing frontmatter");
+  }
+  return parseYaml(match[1]) as Frontmatter;
+}
+
+// Mirror the glob content loader (`**/*.md`): walk recursively and key each post
+// by its path relative to blogDir without the extension, which is exactly the
+// entry id the site uses to build both the URL and the document <link> tag.
+function listPosts(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listPosts(full));
+    } else if (entry.name.endsWith(".md")) {
+      out.push(relative(blogDir, full).replace(/\.md$/u, "").split(sep).join("/"));
+    }
+  }
+  return out;
+}
+
+// Resolve a bsky.app URL or at:// URI to a strong ref (uri + cid). standard.site
+// stores bskyPostRef as a com.atproto.repo.strongRef, which requires the cid, so
+// the AppView is queried for the current post record.
+async function resolveBskyRef(input: string): Promise<StrongRef> {
+  let atUri = input;
+  if (!input.startsWith("at://")) {
+    const match = input.match(/profile\/([^/]+)\/post\/([^/?#]+)/u);
+    if (!match) {
+      throw new Error(`Unrecognized Bluesky post reference: ${input}`);
+    }
+    let actor = match[1];
+    const rkey = match[2];
+    if (!actor.startsWith("did:")) {
+      const res = await fetch(
+        `${PUBLIC_API}/xrpc/com.atproto.identity.resolveHandle?handle=${actor}`,
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to resolve handle ${actor}`);
+      }
+      actor = (await res.json()).did;
+    }
+    atUri = `at://${actor}/app.bsky.feed.post/${rkey}`;
+  }
+  const res = await fetch(
+    `${PUBLIC_API}/xrpc/app.bsky.feed.getPosts?uris=${encodeURIComponent(atUri)}`,
+  );
+  if (!res.ok) {
+    throw new Error(`getPosts failed: ${res.status}`);
+  }
+  const post = (await res.json()).posts?.[0];
+  if (!post?.cid) {
+    throw new Error(`Bluesky post not found: ${atUri}`);
+  }
+  return { uri: post.uri as string, cid: post.cid as string };
+}
+
+const mapping: Mapping = { did: "", publicationRkey: null, documents: {} };
+
+// Persist eagerly so a mid-run failure never strands a freshly minted rkey: the
+// record would exist on the PDS while the mapping forgot it, and the next run
+// would create a duplicate instead of updating.
+function saveMapping(): void {
+  const sorted: Mapping = {
+    did: mapping.did,
+    publicationRkey: mapping.publicationRkey,
+    documents: Object.fromEntries(
+      Object.entries(mapping.documents).toSorted(([a], [b]) => a.localeCompare(b)),
+    ),
+  };
+  // Two-space indent matches the repo's oxfmt config, so the committed mapping
+  // stays format-stable and does not trip the treefmt check after a sync.
+  writeFileSync(mappingPath, `${JSON.stringify(sorted, null, 2)}\n`);
+}
+
+// putRecord only when the stored value actually differs, so unchanged posts stay
+// quiet on the firehose. Returns whether a write happened, for logging.
+async function upsert(
+  did: string,
+  jwt: string,
+  collection: string,
+  rkey: string,
+  record: Record<string, unknown>,
+): Promise<boolean> {
+  const existing = await getRecord(did, collection, rkey);
+  if (existing && canonical(existing) === canonical(record)) {
+    return false;
+  }
+  await xrpc("com.atproto.repo.putRecord", { repo: did, collection, rkey, record }, jwt);
+  return true;
+}
+
+// Resolve identity -> PDS before authenticating so the session, and every record
+// call after it, target whichever host currently serves the account's repo.
+const did = await resolveDid(identifier);
+pds = process.env.PDS_URL ?? (await resolvePds(did));
+
+const session = await xrpc("com.atproto.server.createSession", {
+  identifier,
+  password,
+});
+const jwt = session.accessJwt as string;
+mapping.did = did;
+
+// Recover existing rkeys from the PDS so this run is idempotent regardless of the
+// committed cache. Publications are matched by url (the site can only own one);
+// documents are keyed back to their slug via the `path` this script itself sets.
+const POST_PREFIX = "/posts/";
+const existingPublications = await listAllRecords(did, "site.standard.publication");
+const ownPublication =
+  existingPublications.find((r) => r.value.url === SITE.website) ?? existingPublications[0];
+mapping.publicationRkey = ownPublication ? rkeyOf(ownPublication.uri) : null;
+
+const existingDocuments = await listAllRecords(did, "site.standard.document");
+for (const { uri, value } of existingDocuments) {
+  const path = value.path;
+  if (typeof path === "string" && path.startsWith(POST_PREFIX)) {
+    mapping.documents[path.slice(POST_PREFIX.length)] = rkeyOf(uri);
+  }
+}
+
+// Upsert the publication first so document records can reference its AT-URI.
+const publicationRecord = {
+  $type: "site.standard.publication",
+  name: SITE.title,
+  url: SITE.website,
+  description: SITE.desc,
+};
+if (mapping.publicationRkey) {
+  const changed = await upsert(
+    did,
+    jwt,
+    "site.standard.publication",
+    mapping.publicationRkey,
+    publicationRecord,
+  );
+  console.log(changed ? "updated publication" : "publication unchanged");
+} else {
+  const created = await xrpc(
+    "com.atproto.repo.createRecord",
+    { repo: did, collection: "site.standard.publication", record: publicationRecord },
+    jwt,
+  );
+  mapping.publicationRkey = rkeyOf(created.uri as string);
+  saveMapping();
+  console.log("created publication");
+}
+const publicationUri = `at://${did}/site.standard.publication/${mapping.publicationRkey}`;
+
+const published = new Set<string>();
+for (const slug of listPosts(blogDir)) {
+  const fm = parseFrontmatter(readFileSync(join(blogDir, `${slug}.md`), "utf8"));
+  if (fm.draft) {
+    continue;
+  }
+  published.add(slug);
+
+  const bskyPostRef = fm.bskyPostUri ? await resolveBskyRef(fm.bskyPostUri) : undefined;
+
+  const record = {
+    $type: "site.standard.document",
+    site: publicationUri,
+    title: fm.title,
+    path: `/posts/${slug}`,
+    publishedAt: toIso(fm.pubDatetime),
+    ...(fm.modDatetime ? { updatedAt: toIso(fm.modDatetime) } : {}),
+    ...(fm.description ? { description: fm.description } : {}),
+    ...(fm.tags?.length ? { tags: fm.tags } : {}),
+    ...(bskyPostRef ? { bskyPostRef } : {}),
+  };
+
+  const existing = mapping.documents[slug];
+  if (existing) {
+    const changed = await upsert(did, jwt, "site.standard.document", existing, record);
+    console.log(changed ? `updated ${slug}` : `unchanged ${slug}`);
+  } else {
+    const created = await xrpc(
+      "com.atproto.repo.createRecord",
+      { repo: did, collection: "site.standard.document", record },
+      jwt,
+    );
+    mapping.documents[slug] = rkeyOf(created.uri as string);
+    saveMapping();
+    console.log(`created ${slug}`);
+  }
+}
+
+// Drop records for posts that were removed or switched to draft so the PDS
+// does not keep advertising content the site no longer serves.
+for (const slug of Object.keys(mapping.documents)) {
+  if (!published.has(slug)) {
+    await xrpc(
+      "com.atproto.repo.deleteRecord",
+      {
+        repo: did,
+        collection: "site.standard.document",
+        rkey: mapping.documents[slug],
+      },
+      jwt,
+    );
+    delete mapping.documents[slug];
+    saveMapping();
+    console.log(`deleted ${slug}`);
+  }
+}
+
+saveMapping();
+console.log("standard.site sync complete");

--- a/apps/blog/src/components/Comments.tsx
+++ b/apps/blog/src/components/Comments.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from "react";
+import { LOCALE } from "@config";
+
+// Comments are the replies to a Bluesky post. They are fetched at runtime from
+// the public AppView (no auth, no API key) so threads stay live without a
+// rebuild, rather than being baked in at build time.
+const PUBLIC_API = "https://public.api.bsky.app";
+const BSKY_APP = "https://bsky.app";
+
+interface Author {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+interface PostView {
+  uri: string;
+  cid: string;
+  author: Author;
+  record: { text?: string };
+  replyCount?: number;
+  repostCount?: number;
+  likeCount?: number;
+  indexedAt: string;
+}
+
+interface ThreadViewPost {
+  $type?: string;
+  post: PostView;
+  replies?: ThreadViewPost[];
+}
+
+function rkeyOf(uri: string): string {
+  return uri.split("/").pop() ?? "";
+}
+
+// Link via DID, not handle: a handle that no longer resolves renders as
+// `handle.invalid` and would 404, whereas the DID permalink always works.
+function webUrl(post: PostView): string {
+  return `${BSKY_APP}/profile/${post.author.did}/post/${rkeyOf(post.uri)}`;
+}
+
+function profileUrl(author: Author): string {
+  return `${BSKY_APP}/profile/${author.did}`;
+}
+
+async function resolveAtUri(input: string): Promise<string> {
+  if (input.startsWith("at://")) {
+    return input;
+  }
+  const match = input.match(/profile\/([^/]+)\/post\/([^/?#]+)/u);
+  if (!match) {
+    throw new Error("Unrecognized Bluesky post reference");
+  }
+  let [, actor] = match;
+  const rkey = match[2];
+  if (!actor.startsWith("did:")) {
+    const res = await fetch(
+      `${PUBLIC_API}/xrpc/com.atproto.identity.resolveHandle?handle=${actor}`,
+    );
+    if (!res.ok) {
+      throw new Error("Failed to resolve handle");
+    }
+    actor = (await res.json()).did;
+  }
+  return `at://${actor}/app.bsky.feed.post/${rkey}`;
+}
+
+// Surface the most-engaged replies first; fall back to recency for ties.
+function sortReplies(replies: ThreadViewPost[] = []): ThreadViewPost[] {
+  return [...replies]
+    .filter((r) => r.post?.author)
+    .toSorted((a, b) => {
+      const likes = (b.post.likeCount ?? 0) - (a.post.likeCount ?? 0);
+      return likes === 0 ? b.post.indexedAt.localeCompare(a.post.indexedAt) : likes;
+    });
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(LOCALE.langTag, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function Comment({ comment }: { comment: ThreadViewPost }) {
+  const { post } = comment;
+  return (
+    <div className="mt-4">
+      <div className="flex items-center gap-2">
+        {post.author.avatar && (
+          <img src={post.author.avatar} alt="" className="h-6 w-6 rounded-full" loading="lazy" />
+        )}
+        <a
+          href={profileUrl(post.author)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-blue hover:underline"
+        >
+          {post.author.displayName ?? post.author.handle}
+        </a>
+        <span className="text-sm opacity-60">@{post.author.handle}</span>
+      </div>
+      <p className="mt-1 whitespace-pre-wrap break-words">{post.record.text}</p>
+      <div className="mt-1 flex gap-3 text-xs opacity-60">
+        <a
+          href={webUrl(post)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          {formatDate(post.indexedAt)}
+        </a>
+        <span>♥ {post.likeCount ?? 0}</span>
+        <span>🔁 {post.repostCount ?? 0}</span>
+        <span>💬 {post.replyCount ?? 0}</span>
+      </div>
+      {comment.replies && comment.replies.length > 0 && (
+        <div className="mt-2 border-l border-dashed pl-4">
+          {sortReplies(comment.replies).map((child) => (
+            <Comment key={child.post.uri} comment={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Comments({ postUri }: { postUri: string }) {
+  const [root, setRoot] = useState<ThreadViewPost | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const atUri = await resolveAtUri(postUri);
+        const res = await fetch(
+          `${PUBLIC_API}/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(
+            atUri,
+          )}&depth=10`,
+        );
+        if (!res.ok) {
+          throw new Error(`getPostThread failed: ${res.status}`);
+        }
+        const data = await res.json();
+        const thread = data.thread as ThreadViewPost;
+        if (!thread?.post?.author) {
+          throw new Error("Thread is unavailable");
+        }
+        if (!cancelled) {
+          setRoot(thread);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load comments");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [postUri]);
+
+  const replies = root ? sortReplies(root.replies) : [];
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-2xl font-semibold">Comments</h2>
+      {root && (
+        <p className="mt-1 text-sm opacity-80">
+          Reply on{" "}
+          <a
+            href={webUrl(root.post)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue hover:underline"
+          >
+            Bluesky
+          </a>{" "}
+          to join the conversation.
+        </p>
+      )}
+      {loading && <p className="mt-4 opacity-60">Loading comments…</p>}
+      {error && <p className="mt-4 opacity-60">Could not load comments.</p>}
+      {!loading && !error && replies.length === 0 && (
+        <p className="mt-4 opacity-60">No comments yet.</p>
+      )}
+      {replies.map((reply) => (
+        <Comment key={reply.post.uri} comment={reply} />
+      ))}
+    </section>
+  );
+}

--- a/apps/blog/src/content.config.ts
+++ b/apps/blog/src/content.config.ts
@@ -40,6 +40,9 @@ const blog = defineCollection({
         .optional(),
       description: z.string(),
       canonicalURL: z.string().optional(),
+      // Bluesky post backing the comment thread; accepts a bsky.app URL or an
+      // at:// URI. Same post can be referenced by standard.site's bskyPostRef.
+      bskyPostUri: z.string().optional(),
       editPost: z
         .object({
           disabled: z.boolean().optional(),

--- a/apps/blog/src/data/standard-site.json
+++ b/apps/blog/src/data/standard-site.json
@@ -1,0 +1,5 @@
+{
+  "did": "did:plc:wy2g5mzv3k273vqhns2cxnuy",
+  "publicationRkey": null,
+  "documents": {}
+}

--- a/apps/blog/src/layouts/Layout.astro
+++ b/apps/blog/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "@styles/base.css";
 import "@styles/ogp-card.css";
 import { LOCALE, SITE } from "@config";
 import { ClientRouter } from "astro:transitions";
+import { publicationUri } from "@utils/standardSite";
 
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
@@ -16,6 +17,7 @@ export interface Props {
 	pubDatetime?: Date;
 	modDatetime?: Date | null;
 	scrollSmooth?: boolean;
+	standardSiteDocumentUri?: string;
 }
 
 const {
@@ -28,7 +30,10 @@ const {
 	pubDatetime,
 	modDatetime,
 	scrollSmooth = false,
+	standardSiteDocumentUri,
 } = Astro.props;
+
+const standardSitePublicationUri = publicationUri();
 
 const socialImageURL = new URL(
 	ogImage ?? SITE.ogImage ?? "og.png",
@@ -71,6 +76,21 @@ const structuredData = {
     <meta name="description" content={description} />
     <meta name="author" content={author} />
     <link rel="sitemap" href="/sitemap-index.xml" />
+
+    <!-- standard.site (atproto) record verification -->
+    {
+      standardSitePublicationUri && (
+        <link
+          rel="site.standard.publication"
+          href={standardSitePublicationUri}
+        />
+      )
+    }
+    {
+      standardSiteDocumentUri && (
+        <link rel="site.standard.document" href={standardSiteDocumentUri} />
+      )
+    }
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article" />

--- a/apps/blog/src/layouts/PostDetails.astro
+++ b/apps/blog/src/layouts/PostDetails.astro
@@ -1,5 +1,6 @@
 ---
 import { type CollectionEntry, render } from "astro:content";
+import Comments from "@components/Comments";
 import Datetime from "@components/Datetime";
 import Footer from "@components/Footer.astro";
 import Header from "@components/Header.astro";
@@ -7,6 +8,7 @@ import Layout from "@layouts/Layout.astro";
 import { SITE } from "@config";
 import ShareLinks from "@components/ShareLinks.astro";
 import Tag from "@components/Tag.astro";
+import { documentUri } from "@utils/standardSite";
 import { getOgImageUrl } from "@utils/ogImage";
 import { slugifyStr } from "@utils/slugify";
 
@@ -27,6 +29,7 @@ const {
 	modDatetime,
 	tags,
 	editPost,
+	bskyPostUri,
 } = post.data;
 
 const { Content } = await render(post);
@@ -46,6 +49,7 @@ const layoutProps = {
 	canonicalURL,
 	ogImage: ogUrl,
 	scrollSmooth: true,
+	standardSiteDocumentUri: documentUri(post.id),
 };
 
 /* ========== Prev/Next Posts ========== */
@@ -178,6 +182,15 @@ const nextPost =
         )
       }
     </div>
+
+    {
+      bskyPostUri && (
+        <>
+          <hr class="my-6 border-dashed" />
+          <Comments client:visible postUri={bskyPostUri} />
+        </>
+      )
+    }
   </main>
   <Footer />
 </Layout>

--- a/apps/blog/src/pages/.well-known/site.standard.publication.ts
+++ b/apps/blog/src/pages/.well-known/site.standard.publication.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from "astro";
+import { publicationUri } from "../../utils/standardSite";
+
+// Domain-level proof that links this site back to the publication record.
+// Served as a route (not a public/ file) so the AT-URI stays derived from the
+// single source of truth and is never copied out of sync.
+export const GET: APIRoute = () => {
+  const uri = publicationUri();
+  if (!uri) {
+    return new Response("Not Found", { status: 404 });
+  }
+  return new Response(`${uri}\n`, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/apps/blog/src/utils/standardSite.ts
+++ b/apps/blog/src/utils/standardSite.ts
@@ -1,0 +1,23 @@
+import data from "../data/standard-site.json";
+
+// standard.site records use `key: "tid"`, so record keys cannot be derived from
+// slugs and must be persisted. This module is the read side of that mapping;
+// the write side is scripts/sync-standard-site.ts.
+type StandardSiteData = {
+  did: string;
+  publicationRkey: string | null;
+  documents: Record<string, string>;
+};
+
+const standardSite = data as StandardSiteData;
+
+export function publicationUri(): string | undefined {
+  return standardSite.publicationRkey
+    ? `at://${standardSite.did}/site.standard.publication/${standardSite.publicationRkey}`
+    : undefined;
+}
+
+export function documentUri(slug: string): string | undefined {
+  const rkey = standardSite.documents[slug];
+  return rkey ? `at://${standardSite.did}/site.standard.document/${rkey}` : undefined;
+}


### PR DESCRIPTION
Bring the blog into the AT Protocol ecosystem so posts are discoverable as standard.site records and readers can comment via Bluesky, while keeping the static build and adding no runtime dependencies.

standard.site:
- sync-standard-site.ts upserts site.standard.publication and site.standard.document records to the PDS. Both lexicons declare key=tid, so record keys are server-assigned TIDs that cannot be derived from slugs. Each run recovers the slug->rkey mapping from the PDS itself (listRecords, keyed by each document's path) rather than trusting a committed file, so the sync stays idempotent even from CI where that cache is empty or stale; otherwise a lost rkey would createRecord a duplicate. Records are written with putRecord only when their value actually changed, keeping unchanged posts off the firehose, and rkeys are persisted eagerly so a mid-run failure cannot strand a freshly minted record.
- The target PDS is resolved from the account's DID document each run (identifier->DID->#atproto_pds endpoint) instead of being hard-coded, so a PDS migration is followed automatically: records and AT-URIs are DID-based, so only the host serving them moves. PDS_URL still overrides for local use.
- Posts opting into comments also publish a bskyPostRef strong ref, resolved from the Bluesky post's current uri+cid via the public AppView.
- Verification is wired both ways: a .well-known route and per-page site.standard.{publication,document} link tags, both derived from the mapping (src/data/standard-site.json) as a build-time cache.
- The deploy workflow runs the sync before the production build so the verification tags reflect the current records; it is scoped to main pushes (previews must not mutate the real PDS) and skips until the app-password secret exists so deploys keep working before standard.site is configured.

Bluesky comments:
- Comments.tsx fetches a post thread from the public AppView at runtime (no auth, no rebuild needed) and renders the replies. Opt in per post via the optional bskyPostUri frontmatter field. Profile and permalink links use the author DID so they survive a handle going invalid.

Assisted-by: Claude Code Opus 4.8